### PR TITLE
build(WhitebirdUI): run `pnpm rebuild` if kazam command does not exist

### DIFF
--- a/apps/whitebird-ui/package.json
+++ b/apps/whitebird-ui/package.json
@@ -25,7 +25,7 @@
   "scripts": {
     "prepare": "panda codegen",
     "prebuild": "mkdir -p dist && panda cssgen --outfile dist/whitebird.css",
-    "build": "kazam generate",
+    "build": "kazam generate || (pnpm rebuild && kazam generate)",
     "build:watch": "kazam generate --watch",
     "lint": "eslint .",
     "lint:fix": "eslint . --fix",


### PR DESCRIPTION
In the first installation, kazam command may not be ready because the node_modules/.bin folder is created after total installation, so we need to recreate manually the node_modules/.bin.